### PR TITLE
Add station open and close dates to /monitoringStations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# ── Ricardo API (required for /monitoringStationInfo) ─────────────────────────
+# ── Ricardo API (required for /monitoringStationInfo and monitoring station cache) ──
 RICARDO_API_EMAIL=
 RICARDO_API_PASSWORD=
+RICARDO_API_LOGIN_URL=https://api-ukair.defra.gov.uk/api/login_check
+RICARDO_API_ALL_DATA_URL=https://api-ukair.defra.gov.uk/api/site_meta_datas?
+RICARDO_API_SITE_ID_URL=https://api-ukair.defra.gov.uk/api/pollutant_measurement_datas?
+RICARDO_API_POLLUTANT_METADATA_URL=https://api-ukair.defra.gov.uk/api/pollutant_metadatas
 
 # ── Met Office SFTP (required for /sftp/files and /sftp/file/{filename}) ──────
 SSH_PRIVATE_KEY=
@@ -12,3 +16,4 @@ OS_NAMES_API_KEY=
 # Set to "* * * * *" to trigger every minute, then revert once data is populated.
 # FORECAST_SCHEDULE=0 05-10 * * *
 # POLLUTANTS_SCHEDULE=0 */1 * * *
+# MONITORING_STATIONS_SCHEDULE=0 3 * * *

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,7 @@ services:
 
   mongodb:
     image: mongo:6.0.13
+    container_name: aqie-back-end-mongodb
     networks:
       - cdp-tenant
     ports:

--- a/src/api/locationsite/fetch-monitoring-stations.js
+++ b/src/api/locationsite/fetch-monitoring-stations.js
@@ -3,6 +3,7 @@ import { config } from '../../config/index.js'
 import { catchProxyFetchError } from './helpers/catch-proxy-fetch-error.js'
 import { fetchOAuthToken } from './helpers/oauth-helpers.js'
 import { getLocalAuthorityForCoords } from './helpers/get-local-authority.js'
+import { fetchStationDates } from './helpers/fetch-station-dates.js'
 
 const logger = createLogger()
 
@@ -22,7 +23,10 @@ const logger = createLogger()
  *   areaType: string,
  *   location: { type: 'Point', coordinates: [number, number] },
  *   distance: number|null,
- *   stationStatus: string|null
+ *   stationStatus: string|null,
+ *   openDate: string|null,
+ *   closeDate: string|null,
+ *   pollutants: string[]
  * }>>} Resolves to an array of enriched station objects, or an empty array if
  *   the Ricardo API response is missing or malformed.
  * @throws {Error} If the OAuth token fetch fails.
@@ -62,6 +66,19 @@ async function fetchMonitoringStations() {
 
   const { member: stations } = dataAll
 
+  const { openDates, closeDates, currentPollutants } = await fetchStationDates(
+    accessToken
+  ).catch((err) => {
+    logger.warn(
+      `Failed to fetch station dates: ${err.message} — openDate/closeDate will be null for all stations`
+    )
+    return {
+      openDates: new Map(),
+      closeDates: new Map(),
+      currentPollutants: new Map()
+    }
+  })
+
   return Promise.all(
     stations.map(async (item) => {
       const lat = Number(item.latitude)
@@ -69,6 +86,14 @@ async function fetchMonitoringStations() {
       const localAuthority = await getLocalAuthorityForCoords(lat, lng).catch(
         () => null
       )
+      const stationStatus = item.stationStatus ?? null
+      const rawOpenDate = openDates.get(item.siteId) ?? null
+      const openDate = rawOpenDate ? rawOpenDate.slice(0, 10) : null
+      const rawCloseDate =
+        stationStatus === 'closed'
+          ? (closeDates.get(item.siteId) ?? null)
+          : null
+      const closeDate = rawCloseDate ? rawCloseDate.slice(0, 10) : null
       return {
         name: item.siteName,
         area: item.governmentRegion,
@@ -80,7 +105,10 @@ async function fetchMonitoringStations() {
           coordinates: [lat, lng]
         },
         distance: item.distanceFromPoint,
-        stationStatus: item.stationStatus ?? null
+        stationStatus,
+        openDate,
+        closeDate,
+        pollutants: Array.from(currentPollutants.get(item.siteId) ?? [])
       }
     })
   )

--- a/src/api/locationsite/fetch-monitoring-stations.test.js
+++ b/src/api/locationsite/fetch-monitoring-stations.test.js
@@ -6,6 +6,7 @@ import {
 import { catchProxyFetchError } from './helpers/catch-proxy-fetch-error.js'
 import { fetchOAuthToken } from './helpers/oauth-helpers.js'
 import { getLocalAuthorityForCoords } from './helpers/get-local-authority.js'
+import { fetchStationDates } from './helpers/fetch-station-dates.js'
 
 vi.mock('./helpers/catch-proxy-fetch-error.js', () => ({
   catchProxyFetchError: vi.fn()
@@ -17,6 +18,10 @@ vi.mock('./helpers/oauth-helpers.js', () => ({
 
 vi.mock('./helpers/get-local-authority.js', () => ({
   getLocalAuthorityForCoords: vi.fn()
+}))
+
+vi.mock('./helpers/fetch-station-dates.js', () => ({
+  fetchStationDates: vi.fn()
 }))
 
 vi.mock('../../helpers/logging/logger.js', () => ({
@@ -48,6 +53,11 @@ describe('fetchMonitoringStations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getLocalAuthorityForCoords.mockResolvedValue('Greater London')
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map(),
+      closeDates: new Map(),
+      currentPollutants: new Map()
+    })
   })
 
   it('returns a mapped array of station objects on success', async () => {
@@ -185,6 +195,145 @@ describe('fetchMonitoringStations', () => {
 
     const calledUrl = catchProxyFetchError.mock.calls[0][0]
     expect(calledUrl).toContain('with-closed=true')
+  })
+
+  it('sets openDate from fetchStationDates when a matching siteId is found', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [mockMember(1)] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map([['SITE1', '2006-06-15T00:00:00+01:00']]),
+      closeDates: new Map(),
+      currentPollutants: new Map()
+    })
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].openDate).toBe('2006-06-15')
+  })
+
+  it('sets openDate using the date portion of the raw value without UTC conversion', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [mockMember(1)] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map([['SITE1', '2006-06-15T00:00:00+01:00']]),
+      closeDates: new Map(),
+      currentPollutants: new Map()
+    })
+
+    const result = await fetchMonitoringStations()
+
+    // Must be the calendar date from the source string, not UTC-shifted
+    expect(result[0].openDate).not.toBe('2006-06-14')
+  })
+
+  it('sets openDate to null when no matching siteId in the open dates map', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [mockMember(1)] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map(),
+      closeDates: new Map(),
+      currentPollutants: new Map()
+    })
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].openDate).toBeNull()
+  })
+
+  it('sets openDate and closeDate to null for all stations when fetchStationDates rejects', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([
+      200,
+      { member: [mockMember(1), mockMember(2)] }
+    ])
+    fetchStationDates.mockRejectedValue(new Error('Ricardo timeout'))
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].openDate).toBeNull()
+    expect(result[0].closeDate).toBeNull()
+    expect(result[1].openDate).toBeNull()
+    expect(result[1].closeDate).toBeNull()
+  })
+
+  it('sets closeDate for closed stations when a matching siteId is found', async () => {
+    const closedMember = { ...mockMember(1), stationStatus: 'closed' }
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [closedMember] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map([['SITE1', '2006-06-15T00:00:00+01:00']]),
+      closeDates: new Map([['SITE1', '2018-03-20T00:00:00+00:00']]),
+      currentPollutants: new Map()
+    })
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].closeDate).toBe('2018-03-20')
+  })
+
+  it('sets closeDate to null for active stations even when closeDates map has an entry', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [mockMember(1)] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map(),
+      closeDates: new Map([['SITE1', '2018-03-20T00:00:00+00:00']]),
+      currentPollutants: new Map()
+    })
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].closeDate).toBeNull()
+  })
+
+  it('passes the access token to fetchStationDates', async () => {
+    fetchOAuthToken.mockResolvedValue('my-access-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [] }])
+
+    await fetchMonitoringStations()
+
+    expect(fetchStationDates).toHaveBeenCalledWith('my-access-token')
+  })
+
+  it('sets pollutants from currentPollutants map for matching siteId', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [mockMember(1)] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map(),
+      closeDates: new Map(),
+      currentPollutants: new Map([['SITE1', new Set(['NO2', 'O3'])]])
+    })
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].pollutants).toEqual(['NO2', 'O3'])
+  })
+
+  it('sets pollutants to empty array when no entry in currentPollutants', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([200, { member: [mockMember(1)] }])
+    fetchStationDates.mockResolvedValue({
+      openDates: new Map(),
+      closeDates: new Map(),
+      currentPollutants: new Map()
+    })
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].pollutants).toEqual([])
+  })
+
+  it('sets pollutants to empty array for all stations when fetchStationDates rejects', async () => {
+    fetchOAuthToken.mockResolvedValue('valid-token')
+    catchProxyFetchError.mockResolvedValue([
+      200,
+      { member: [mockMember(1), mockMember(2)] }
+    ])
+    fetchStationDates.mockRejectedValue(new Error('Ricardo timeout'))
+
+    const result = await fetchMonitoringStations()
+
+    expect(result[0].pollutants).toEqual([])
+    expect(result[1].pollutants).toEqual([])
   })
 })
 

--- a/src/api/locationsite/helpers/fetch-station-dates.js
+++ b/src/api/locationsite/helpers/fetch-station-dates.js
@@ -15,7 +15,8 @@ const logger = createLogger()
 function pollutantNameToCode(name) {
   const n = name
     .toLowerCase()
-    .replace(/<[^>]*>/g, '')
+    .replaceAll('<sub>', '')
+    .replaceAll('</sub>', '')
     .trim()
   if (n.includes('2.5')) return 'PM25'
   if (n.includes('pm10') || n.includes('pm 10')) return 'PM10'

--- a/src/api/locationsite/helpers/fetch-station-dates.js
+++ b/src/api/locationsite/helpers/fetch-station-dates.js
@@ -3,6 +3,10 @@ import { createLogger } from '../../../helpers/logging/logger.js'
 
 const logger = createLogger()
 
+const POLLUTANT_METADATA_PAGE_SIZE = 30
+const POLLUTANT_METADATA_FALLBACK_MAX_PAGES = 600
+const POLLUTANT_METADATA_PAGE_COUNT_BUFFER = 1.2
+
 /**
  * Maps a Ricardo pollutant name to a short DAQI code.
  * Returns null for pollutants not relevant to DAQI filtering.
@@ -48,7 +52,9 @@ function pollutantNameToCode(name) {
 function resolveMaxPages(firstPageData, fallbackMaxPages, pageSize) {
   const totalItems = firstPageData.totalItems
   if (typeof totalItems === 'number' && totalItems > 0) {
-    const pages = Math.ceil((totalItems / pageSize) * 1.2)
+    const pages = Math.ceil(
+      (totalItems / pageSize) * POLLUTANT_METADATA_PAGE_COUNT_BUFFER
+    )
     logger.info(
       `Fetching pollutant metadata: ${totalItems} total items, max pages set to ${pages}`
     )
@@ -61,6 +67,26 @@ function resolveMaxPages(firstPageData, fallbackMaxPages, pageSize) {
 }
 
 /**
+ * Fetches a single page of pollutant metadata records.
+ * Returns null and logs a warning if the response is not ok.
+ *
+ * @param {string} baseUrl
+ * @param {Record<string, string>} headers
+ * @param {number} page
+ * @returns {Promise<object|null>}
+ */
+async function fetchPollutantMetadataPage(baseUrl, headers, page) {
+  const response = await fetch(`${baseUrl}?page=${page}`, { headers })
+  if (!response.ok) {
+    logger.warn(
+      `pollutant_metadatas page ${page} returned HTTP ${response.status} — stopping pagination`
+    )
+    return null
+  }
+  return response.json()
+}
+
+/**
  * Fetches all pages of /api/pollutant_metadatas from the Ricardo API and
  * returns the raw array of records.
  *
@@ -69,36 +95,29 @@ function resolveMaxPages(firstPageData, fallbackMaxPages, pageSize) {
  * @returns {Promise<Array<object>>} All pollutant metadata records across all pages.
  */
 async function fetchAllPollutantMetadataRecords(baseUrl, headers) {
-  const PAGE_SIZE = 30
-  const FALLBACK_MAX_PAGES = 600
-  let maxPages = FALLBACK_MAX_PAGES
+  let maxPages = POLLUTANT_METADATA_FALLBACK_MAX_PAGES
   let page = 1
   const records = []
 
   while (page <= maxPages) {
-    const response = await fetch(`${baseUrl}?page=${page}`, { headers })
+    const data = await fetchPollutantMetadataPage(baseUrl, headers, page)
 
-    if (!response.ok) {
-      logger.warn(
-        `pollutant_metadatas page ${page} returned HTTP ${response.status} — stopping pagination`
+    if (page === 1 && data) {
+      maxPages = resolveMaxPages(
+        data,
+        POLLUTANT_METADATA_FALLBACK_MAX_PAGES,
+        POLLUTANT_METADATA_PAGE_SIZE
       )
-      break
     }
 
-    const data = await response.json()
-
-    if (page === 1) {
-      maxPages = resolveMaxPages(data, FALLBACK_MAX_PAGES, PAGE_SIZE)
-    }
-
-    const pageRecords = data.member ?? []
-    if (pageRecords.length === 0) {
-      break
-    }
-
+    const pageRecords = data?.member ?? []
     records.push(...pageRecords)
 
-    if (pageRecords.length < PAGE_SIZE) {
+    const isLastPage =
+      !data ||
+      pageRecords.length === 0 ||
+      pageRecords.length < POLLUTANT_METADATA_PAGE_SIZE
+    if (isLastPage) {
       break
     }
 
@@ -119,7 +138,10 @@ function updateOpenDate(openDates, record) {
     return
   }
   const existing = openDates.get(record.siteId)
-  if (!existing || record.startDate < existing) {
+  const isEarlier =
+    !existing ||
+    new Date(record.startDate).getTime() < new Date(existing).getTime()
+  if (isEarlier) {
     openDates.set(record.siteId, record.startDate)
   }
 }
@@ -135,7 +157,10 @@ function updateCloseDate(closeDates, record) {
     return
   }
   const existing = closeDates.get(record.siteId)
-  if (!existing || record.endDate > existing) {
+  const isLater =
+    !existing ||
+    new Date(record.endDate).getTime() > new Date(existing).getTime()
+  if (isLater) {
     closeDates.set(record.siteId, record.endDate)
   }
 }

--- a/src/api/locationsite/helpers/fetch-station-dates.js
+++ b/src/api/locationsite/helpers/fetch-station-dates.js
@@ -18,16 +18,46 @@ function pollutantNameToCode(name) {
     .replaceAll('<sub>', '')
     .replaceAll('</sub>', '')
     .trim()
-  if (n.includes('2.5')) return 'PM25'
-  if (n.includes('pm10') || n.includes('pm 10')) return 'PM10'
+  if (n.includes('2.5')) {
+    return 'PM25'
+  }
+  if (n.includes('pm10') || n.includes('pm 10')) {
+    return 'PM10'
+  }
   if (n.includes('nitrogen dioxide') && !n.includes('nitrogen oxides')) {
     return 'NO2'
   }
-  if (n.includes('ozone')) return 'O3'
+  if (n.includes('ozone')) {
+    return 'O3'
+  }
   if (n.includes('sulphur dioxide') || n.includes('sulfur dioxide')) {
     return 'SO2'
   }
   return null
+}
+
+/**
+ * Derives the maximum number of pages to fetch from page 1 response data.
+ * Adds a 20% buffer above the calculated page count to handle data growth.
+ *
+ * @param {object} firstPageData - Parsed JSON from the first page response.
+ * @param {number} fallbackMaxPages - Cap to use when totalItems is missing.
+ * @param {number} pageSize - Number of records per page.
+ * @returns {number}
+ */
+function resolveMaxPages(firstPageData, fallbackMaxPages, pageSize) {
+  const totalItems = firstPageData.totalItems
+  if (typeof totalItems === 'number' && totalItems > 0) {
+    const pages = Math.ceil((totalItems / pageSize) * 1.2)
+    logger.info(
+      `Fetching pollutant metadata: ${totalItems} total items, max pages set to ${pages}`
+    )
+    return pages
+  }
+  logger.warn(
+    `pollutant_metadatas totalItems missing or invalid — using fallback cap of ${fallbackMaxPages} pages`
+  )
+  return fallbackMaxPages
 }
 
 /**
@@ -58,30 +88,76 @@ async function fetchAllPollutantMetadataRecords(baseUrl, headers) {
     const data = await response.json()
 
     if (page === 1) {
-      const totalItems = data.totalItems
-      if (typeof totalItems === 'number' && totalItems > 0) {
-        maxPages = Math.ceil((totalItems / PAGE_SIZE) * 1.2)
-        logger.info(
-          `Fetching pollutant metadata: ${totalItems} total items, max pages set to ${maxPages}`
-        )
-      } else {
-        logger.warn(
-          `pollutant_metadatas totalItems missing or invalid — using fallback cap of ${FALLBACK_MAX_PAGES} pages`
-        )
-      }
+      maxPages = resolveMaxPages(data, FALLBACK_MAX_PAGES, PAGE_SIZE)
     }
 
     const pageRecords = data.member ?? []
-    if (pageRecords.length === 0) break
+    if (pageRecords.length === 0) {
+      break
+    }
 
     records.push(...pageRecords)
 
-    if (pageRecords.length < PAGE_SIZE) break
+    if (pageRecords.length < PAGE_SIZE) {
+      break
+    }
 
     page++
   }
 
   return records
+}
+
+/**
+ * Updates the openDates map with the earliest startDate for a station.
+ *
+ * @param {Map<string, string>} openDates
+ * @param {{ siteId: string, startDate?: string }} record
+ */
+function updateOpenDate(openDates, record) {
+  if (!record.startDate) {
+    return
+  }
+  const existing = openDates.get(record.siteId)
+  if (!existing || record.startDate < existing) {
+    openDates.set(record.siteId, record.startDate)
+  }
+}
+
+/**
+ * Updates the closeDates map with the latest endDate for closed stations.
+ *
+ * @param {Map<string, string>} closeDates
+ * @param {{ siteId: string, endDate?: string, measurementStatus?: string }} record
+ */
+function updateCloseDate(closeDates, record) {
+  if (!record.endDate || record.measurementStatus !== 'closed') {
+    return
+  }
+  const existing = closeDates.get(record.siteId)
+  if (!existing || record.endDate > existing) {
+    closeDates.set(record.siteId, record.endDate)
+  }
+}
+
+/**
+ * Updates the currentPollutants map with DAQI codes for active instruments.
+ *
+ * @param {Map<string, Set<string>>} currentPollutants
+ * @param {{ siteId: string, measurementStatus?: string, pollutantName?: string }} record
+ */
+function updateCurrentPollutants(currentPollutants, record) {
+  if (record.measurementStatus !== 'current' || !record.pollutantName) {
+    return
+  }
+  const code = pollutantNameToCode(record.pollutantName)
+  if (!code) {
+    return
+  }
+  if (!currentPollutants.has(record.siteId)) {
+    currentPollutants.set(record.siteId, new Set())
+  }
+  currentPollutants.get(record.siteId).add(code)
 }
 
 /**
@@ -104,31 +180,12 @@ function buildStationDatesMap(records) {
   const currentPollutants = new Map()
 
   for (const record of records) {
-    if (!record.siteId) continue
-
-    if (record.startDate) {
-      const existing = openDates.get(record.siteId)
-      if (!existing || record.startDate < existing) {
-        openDates.set(record.siteId, record.startDate)
-      }
+    if (!record.siteId) {
+      continue
     }
-
-    if (record.endDate && record.measurementStatus === 'closed') {
-      const existing = closeDates.get(record.siteId)
-      if (!existing || record.endDate > existing) {
-        closeDates.set(record.siteId, record.endDate)
-      }
-    }
-
-    if (record.measurementStatus === 'current' && record.pollutantName) {
-      const code = pollutantNameToCode(record.pollutantName)
-      if (code) {
-        if (!currentPollutants.has(record.siteId)) {
-          currentPollutants.set(record.siteId, new Set())
-        }
-        currentPollutants.get(record.siteId).add(code)
-      }
-    }
+    updateOpenDate(openDates, record)
+    updateCloseDate(closeDates, record)
+    updateCurrentPollutants(currentPollutants, record)
   }
 
   return { openDates, closeDates, currentPollutants }

--- a/src/api/locationsite/helpers/fetch-station-dates.js
+++ b/src/api/locationsite/helpers/fetch-station-dates.js
@@ -1,0 +1,160 @@
+import { config } from '../../../config/index.js'
+import { createLogger } from '../../../helpers/logging/logger.js'
+
+const logger = createLogger()
+
+/**
+ * Maps a Ricardo pollutant name to a short DAQI code.
+ * Returns null for pollutants not relevant to DAQI filtering.
+ *
+ * Ricardo names contain HTML (e.g. PM<sub>10</sub>) which is stripped before matching.
+ *
+ * @param {string} name - A pollutantName value from the Ricardo API.
+ * @returns {string|null} Short code (e.g. 'PM10', 'NO2') or null if not a DAQI pollutant.
+ */
+function pollutantNameToCode(name) {
+  const n = name
+    .toLowerCase()
+    .replace(/<[^>]*>/g, '')
+    .trim()
+  if (n.includes('2.5')) return 'PM25'
+  if (n.includes('pm10') || n.includes('pm 10')) return 'PM10'
+  if (n.includes('nitrogen dioxide') && !n.includes('nitrogen oxides')) {
+    return 'NO2'
+  }
+  if (n.includes('ozone')) return 'O3'
+  if (n.includes('sulphur dioxide') || n.includes('sulfur dioxide')) {
+    return 'SO2'
+  }
+  return null
+}
+
+/**
+ * Fetches all pages of /api/pollutant_metadatas from the Ricardo API and
+ * returns the raw array of records.
+ *
+ * @param {string} baseUrl - The pollutant_metadatas endpoint URL.
+ * @param {Record<string, string>} headers - Auth headers to include on each request.
+ * @returns {Promise<Array<object>>} All pollutant metadata records across all pages.
+ */
+async function fetchAllPollutantMetadataRecords(baseUrl, headers) {
+  const PAGE_SIZE = 30
+  const FALLBACK_MAX_PAGES = 600
+  let maxPages = FALLBACK_MAX_PAGES
+  let page = 1
+  const records = []
+
+  while (page <= maxPages) {
+    const response = await fetch(`${baseUrl}?page=${page}`, { headers })
+
+    if (!response.ok) {
+      logger.warn(
+        `pollutant_metadatas page ${page} returned HTTP ${response.status} — stopping pagination`
+      )
+      break
+    }
+
+    const data = await response.json()
+
+    if (page === 1) {
+      const totalItems = data.totalItems
+      if (typeof totalItems === 'number' && totalItems > 0) {
+        maxPages = Math.ceil((totalItems / PAGE_SIZE) * 1.2)
+        logger.info(
+          `Fetching pollutant metadata: ${totalItems} total items, max pages set to ${maxPages}`
+        )
+      } else {
+        logger.warn(
+          `pollutant_metadatas totalItems missing or invalid — using fallback cap of ${FALLBACK_MAX_PAGES} pages`
+        )
+      }
+    }
+
+    const pageRecords = data.member ?? []
+    if (pageRecords.length === 0) break
+
+    records.push(...pageRecords)
+
+    if (pageRecords.length < PAGE_SIZE) break
+
+    page++
+  }
+
+  return records
+}
+
+/**
+ * Reduces an array of pollutant metadata records into maps of open and close
+ * dates keyed by siteId.
+ *
+ * - openDate:  earliest startDate across all pollutant records for the station
+ *              (i.e. when the station first began collecting data).
+ * - closeDate: latest endDate across all closed pollutant records for the station
+ *              (i.e. when the last instrument was decommissioned).
+ * - currentPollutants: set of DAQI short codes for currently active instruments
+ *              (e.g. 'NO2', 'PM10', 'O3').
+ *
+ * @param {Array<object>} records - Raw pollutant metadata records.
+ * @returns {{ openDates: Map<string, string>, closeDates: Map<string, string>, currentPollutants: Map<string, Set<string>> }}
+ */
+function buildStationDatesMap(records) {
+  const openDates = new Map()
+  const closeDates = new Map()
+  const currentPollutants = new Map()
+
+  for (const record of records) {
+    if (!record.siteId) continue
+
+    if (record.startDate) {
+      const existing = openDates.get(record.siteId)
+      if (!existing || record.startDate < existing) {
+        openDates.set(record.siteId, record.startDate)
+      }
+    }
+
+    if (record.endDate && record.measurementStatus === 'closed') {
+      const existing = closeDates.get(record.siteId)
+      if (!existing || record.endDate > existing) {
+        closeDates.set(record.siteId, record.endDate)
+      }
+    }
+
+    if (record.measurementStatus === 'current' && record.pollutantName) {
+      const code = pollutantNameToCode(record.pollutantName)
+      if (code) {
+        if (!currentPollutants.has(record.siteId)) {
+          currentPollutants.set(record.siteId, new Set())
+        }
+        currentPollutants.get(record.siteId).add(code)
+      }
+    }
+  }
+
+  return { openDates, closeDates, currentPollutants }
+}
+
+/**
+ * Fetches all pages of /api/pollutant_metadatas from the Ricardo API and
+ * returns open and close date maps for all stations.
+ *
+ * @param {string} accessToken - A valid Ricardo API Bearer token.
+ * @returns {Promise<{ openDates: Map<string, string>, closeDates: Map<string, string>, currentPollutants: Map<string, Set<string>> }>}
+ */
+async function fetchStationDates(accessToken) {
+  const baseUrl = config.get('ricardoApiPollutantMetadataUrl')
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json'
+  }
+
+  const records = await fetchAllPollutantMetadataRecords(baseUrl, headers)
+  const { openDates, closeDates, currentPollutants } =
+    buildStationDatesMap(records)
+
+  logger.info(
+    `pollutant_metadatas fetch complete: open dates for ${openDates.size} stations, close dates for ${closeDates.size} stations, current pollutants for ${currentPollutants.size} stations`
+  )
+  return { openDates, closeDates, currentPollutants }
+}
+
+export { fetchStationDates, buildStationDatesMap, pollutantNameToCode }

--- a/src/api/locationsite/helpers/fetch-station-dates.test.js
+++ b/src/api/locationsite/helpers/fetch-station-dates.test.js
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  fetchStationDates,
+  buildStationDatesMap,
+  pollutantNameToCode
+} from './fetch-station-dates.js'
+
+vi.mock('../../../config/index.js', () => ({
+  config: {
+    get: vi.fn((key) => {
+      if (key === 'ricardoApiPollutantMetadataUrl') {
+        return 'https://mock-ricardo/api/pollutant_metadatas'
+      }
+      return null
+    })
+  }
+}))
+
+vi.mock('../../../helpers/logging/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn() })
+}))
+
+const makeRecord = (siteId, startDate, extra = {}) => ({
+  siteId,
+  startDate,
+  pollutantName: 'Ozone',
+  measurementStatus: 'current',
+  ...extra
+})
+
+const makePage = (members, totalItems = members.length) => ({
+  totalItems,
+  member: members
+})
+
+describe('pollutantNameToCode', () => {
+  it.each([
+    ['Nitrogen dioxide', 'NO2'],
+    ['Ozone', 'O3'],
+    ['Sulphur dioxide', 'SO2'],
+    ['Sulfur dioxide', 'SO2'],
+    ['PM<sub>10</sub> particulate matter (Hourly measured)', 'PM10'],
+    ['Non-volatile PM<sub>10</sub> (Hourly measured)', 'PM10'],
+    ['PM 10 particulate matter', 'PM10'],
+    ['PM<sub>2.5</sub> particulate matter (Hourly measured)', 'PM25'],
+    ['Non-volatile PM2.5 (Hourly measured)', 'PM25']
+  ])('%s → %s', (name, expected) => {
+    expect(pollutantNameToCode(name)).toBe(expected)
+  })
+
+  it('returns null for unmapped pollutants', () => {
+    expect(pollutantNameToCode('Carbon monoxide')).toBeNull()
+    expect(pollutantNameToCode('Nitric oxide')).toBeNull()
+    expect(
+      pollutantNameToCode('Nitrogen oxides as nitrogen dioxide')
+    ).toBeNull()
+  })
+})
+
+describe('buildStationDatesMap', () => {
+  describe('openDates', () => {
+    it('returns empty maps for an empty records array', () => {
+      const { openDates, closeDates, currentPollutants } = buildStationDatesMap(
+        []
+      )
+      expect(openDates.size).toBe(0)
+      expect(closeDates.size).toBe(0)
+      expect(currentPollutants.size).toBe(0)
+    })
+
+    it('maps a single record to its startDate', () => {
+      const { openDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00')
+      ])
+      expect(openDates.get('UKA00001')).toBe('2010-01-01T00:00:00+00:00')
+    })
+
+    it('picks the earliest startDate across multiple records for the same station', () => {
+      const { openDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2012-06-01T00:00:00+00:00'),
+        makeRecord('UKA00001', '2006-06-15T00:00:00+01:00'),
+        makeRecord('UKA00001', '2009-03-10T00:00:00+00:00')
+      ])
+      expect(openDates.get('UKA00001')).toBe('2006-06-15T00:00:00+01:00')
+    })
+
+    it('handles multiple stations independently', () => {
+      const { openDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00'),
+        makeRecord('UKA00002', '2005-03-15T00:00:00+00:00'),
+        makeRecord('UKA00001', '2008-07-20T00:00:00+00:00')
+      ])
+      expect(openDates.get('UKA00001')).toBe('2008-07-20T00:00:00+00:00')
+      expect(openDates.get('UKA00002')).toBe('2005-03-15T00:00:00+00:00')
+    })
+
+    it('skips records missing siteId', () => {
+      const { openDates } = buildStationDatesMap([
+        { startDate: '2010-01-01T00:00:00+00:00' },
+        makeRecord('UKA00001', '2010-06-01T00:00:00+00:00')
+      ])
+      expect(openDates.size).toBe(1)
+    })
+
+    it('skips records missing startDate', () => {
+      const { openDates } = buildStationDatesMap([
+        { siteId: 'UKA00001' },
+        makeRecord('UKA00002', '2010-06-01T00:00:00+00:00')
+      ])
+      expect(openDates.size).toBe(1)
+      expect(openDates.get('UKA00002')).toBeDefined()
+    })
+  })
+
+  describe('closeDates', () => {
+    it('picks the latest endDate from closed pollutant records', () => {
+      const { closeDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2006-01-01T00:00:00+00:00', {
+          endDate: '2010-06-01T00:00:00+00:00',
+          measurementStatus: 'closed'
+        }),
+        makeRecord('UKA00001', '2006-01-01T00:00:00+00:00', {
+          endDate: '2015-03-15T00:00:00+00:00',
+          measurementStatus: 'closed'
+        })
+      ])
+      expect(closeDates.get('UKA00001')).toBe('2015-03-15T00:00:00+00:00')
+    })
+
+    it('does not set a closeDate for stations with only current pollutants', () => {
+      const { closeDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          measurementStatus: 'current'
+        })
+      ])
+      expect(closeDates.has('UKA00001')).toBe(false)
+    })
+
+    it('ignores endDate on records where measurementStatus is not closed', () => {
+      const { closeDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          endDate: '2024-01-01T00:00:00+00:00',
+          measurementStatus: 'current'
+        })
+      ])
+      expect(closeDates.has('UKA00001')).toBe(false)
+    })
+
+    it('skips closed records missing endDate', () => {
+      const { closeDates } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          measurementStatus: 'closed'
+        })
+      ])
+      expect(closeDates.has('UKA00001')).toBe(false)
+    })
+  })
+
+  describe('currentPollutants', () => {
+    it('collects current pollutant codes for a station', () => {
+      const { currentPollutants } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          pollutantName: 'Nitrogen dioxide',
+          measurementStatus: 'current'
+        }),
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          pollutantName: 'Ozone',
+          measurementStatus: 'current'
+        })
+      ])
+      expect(currentPollutants.get('UKA00001')).toEqual(new Set(['NO2', 'O3']))
+    })
+
+    it('does not include closed pollutants', () => {
+      const { currentPollutants } = buildStationDatesMap([
+        makeRecord('UKA00001', '2006-01-01T00:00:00+00:00', {
+          pollutantName: 'Carbon monoxide',
+          measurementStatus: 'closed',
+          endDate: '2012-01-01T00:00:00+00:00'
+        }),
+        makeRecord('UKA00001', '2006-01-01T00:00:00+00:00', {
+          pollutantName: 'Nitrogen dioxide',
+          measurementStatus: 'current'
+        })
+      ])
+      expect(currentPollutants.get('UKA00001')).toEqual(new Set(['NO2']))
+    })
+
+    it('does not include unmapped pollutant names', () => {
+      const { currentPollutants } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          pollutantName: 'Carbon monoxide',
+          measurementStatus: 'current'
+        })
+      ])
+      expect(currentPollutants.has('UKA00001')).toBe(false)
+    })
+
+    it('correctly maps Ricardo HTML pollutant names to short codes', () => {
+      const { currentPollutants } = buildStationDatesMap([
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          pollutantName: 'PM<sub>10</sub> particulate matter (Hourly measured)',
+          measurementStatus: 'current'
+        }),
+        makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+          pollutantName:
+            'PM<sub>2.5</sub> particulate matter (Hourly measured)',
+          measurementStatus: 'current'
+        })
+      ])
+      expect(currentPollutants.get('UKA00001')).toEqual(
+        new Set(['PM10', 'PM25'])
+      )
+    })
+
+    it('returns empty currentPollutants map for empty records', () => {
+      const { currentPollutants } = buildStationDatesMap([])
+      expect(currentPollutants.size).toBe(0)
+    })
+  })
+})
+
+describe('fetchStationDates', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  const mockFetchPage = (members, totalItems) => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makePage(members, totalItems)
+    })
+  }
+
+  it('returns openDates, closeDates and currentPollutants maps from a single page response', async () => {
+    mockFetchPage([
+      makeRecord('UKA00001', '2010-01-01T00:00:00+00:00', {
+        pollutantName: 'Nitrogen dioxide',
+        measurementStatus: 'current'
+      }),
+      makeRecord('UKA00002', '2005-03-15T00:00:00+00:00', {
+        endDate: '2018-06-01T00:00:00+00:00',
+        measurementStatus: 'closed'
+      })
+    ])
+
+    const { openDates, closeDates, currentPollutants } =
+      await fetchStationDates('test-token')
+
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledWith(
+      'https://mock-ricardo/api/pollutant_metadatas?page=1',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' })
+      })
+    )
+    expect(openDates.get('UKA00001')).toBe('2010-01-01T00:00:00+00:00')
+    expect(openDates.get('UKA00002')).toBe('2005-03-15T00:00:00+00:00')
+    expect(closeDates.get('UKA00002')).toBe('2018-06-01T00:00:00+00:00')
+    expect(closeDates.has('UKA00001')).toBe(false)
+    expect(currentPollutants.get('UKA00001')).toEqual(new Set(['NO2']))
+  })
+
+  it('paginates until a partial page signals the last page', async () => {
+    const fullPage = Array.from({ length: 30 }, (_, i) =>
+      makeRecord(
+        `UKA${String(i).padStart(5, '0')}`,
+        '2010-01-01T00:00:00+00:00'
+      )
+    )
+    const partialPage = [makeRecord('UKA00031', '2010-01-01T00:00:00+00:00')]
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makePage(fullPage, 31)
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makePage(partialPage, 31)
+      })
+
+    const { openDates } = await fetchStationDates('test-token')
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(openDates.size).toBe(31)
+  })
+
+  it('stops pagination and returns partial results when a page returns non-ok', async () => {
+    const fullPage = Array.from({ length: 30 }, (_, i) =>
+      makeRecord(
+        `UKA${String(i).padStart(5, '0')}`,
+        '2010-01-01T00:00:00+00:00'
+      )
+    )
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makePage(fullPage, 60)
+      })
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+
+    const { openDates } = await fetchStationDates('test-token')
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(openDates.size).toBe(30)
+  })
+
+  it('returns empty maps when the first page has no members', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makePage([], 0)
+    })
+
+    const { openDates, closeDates, currentPollutants } =
+      await fetchStationDates('test-token')
+
+    expect(openDates.size).toBe(0)
+    expect(closeDates.size).toBe(0)
+    expect(currentPollutants.size).toBe(0)
+  })
+
+  it('uses fallback max pages when totalItems is missing from page 1', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        member: [makeRecord('UKA00001', '2010-01-01T00:00:00+00:00')]
+      })
+    })
+
+    const { openDates } = await fetchStationDates('test-token')
+
+    expect(openDates.get('UKA00001')).toBeDefined()
+  })
+
+  it('derives maxPages from totalItems with a 20% buffer', async () => {
+    const fullPage = Array.from({ length: 30 }, (_, i) =>
+      makeRecord(
+        `UKA${String(i).padStart(5, '0')}`,
+        '2010-01-01T00:00:00+00:00'
+      )
+    )
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makePage(fullPage, 30)
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => makePage([], 30) })
+
+    const { openDates } = await fetchStationDates('test-token')
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(openDates.size).toBe(30)
+  })
+})

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -276,6 +276,12 @@ const config = convict({
       'https://uk-air-api.staging.rcdo.co.uk/api/pollutant_measurement_datas?',
     env: 'RICARDO_API_SITE_ID_URL'
   },
+  ricardoApiPollutantMetadataUrl: {
+    doc: 'Ricardo API pollutant metadata url (used to derive station establishment dates)',
+    format: String,
+    default: 'https://uk-air-api.staging.rcdo.co.uk/api/pollutant_metadatas',
+    env: 'RICARDO_API_POLLUTANT_METADATA_URL'
+  },
   ricardoApiEmail: {
     doc: 'Ricardo API email',
     format: String,


### PR DESCRIPTION
The /monitoringStations endpoint has been updated to also provide open dates, close dates and pollutant codes for each monitoring station, obtained by fetching from the Ricardo pollutant_metadatas API endpoint. These are needed by the maps prototype to display station dates and filter by pollutant type. This update removes the dependency on /measurements, which will be deprecated in the future.

More details can be found in this [ticket](https://eaflood.atlassian.net/browse/AQC-895?atlOrigin=eyJpIjoiZmQxMmMxY2M3OWZjNDE4NDgxNzRlY2ZkNWQyMWE2MmEiLCJwIjoiaiJ9) 