### PR TITLE
Security fix applied to stop logging SFTP private key

### DIFF
--- a/src/api/locationsite/helpers/oauth-helpers.js
+++ b/src/api/locationsite/helpers/oauth-helpers.js
@@ -27,18 +27,13 @@ async function fetchOAuthToken(catchProxyFetchError, logger) {
     )
 
     logger.info(`OAuth response status: ${statusCodeToken}`)
-    logger.info(`OAuth response data: ${JSON.stringify(dataToken)}`)
 
     if (statusCodeToken !== HTTP_OK) {
-      throw new Error(
-        `Error fetching OAuth token: HTTP ${statusCodeToken} - ${JSON.stringify(dataToken)}`
-      )
+      throw new Error(`Error fetching OAuth token: HTTP ${statusCodeToken}`)
     }
 
     if (!dataToken?.token) {
-      throw new Error(
-        `Invalid OAuth response: missing token field in ${JSON.stringify(dataToken)}`
-      )
+      throw new Error('Invalid OAuth response: missing token field')
     }
 
     const accessToken = dataToken.token

--- a/src/api/locationsite/helpers/oauth-helpers.test.js
+++ b/src/api/locationsite/helpers/oauth-helpers.test.js
@@ -86,7 +86,7 @@ describe('#oauth-helpers', () => {
 
       expect(token).toBeNull()
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error fetching OAuth token: Error fetching OAuth token: HTTP 401 - {"error":"invalid_credentials"}'
+        'Error fetching OAuth token: Error fetching OAuth token: HTTP 401'
       )
       expect(mockLogger.info).toHaveBeenCalledWith(
         'Completed fetchOAuthTokenNewRicardoAPI execution'
@@ -137,7 +137,7 @@ describe('#oauth-helpers', () => {
 
       expect(token).toBeNull()
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error fetching OAuth token: Error fetching OAuth token: HTTP 500 - {"error":"server_error"}'
+        'Error fetching OAuth token: Error fetching OAuth token: HTTP 500'
       )
     })
 
@@ -172,6 +172,36 @@ describe('#oauth-helpers', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Invalid OAuth response')
       )
+    })
+  })
+
+  describe('#secret logging safeguard', () => {
+    test('Should never write the bearer token value to any log', async () => {
+      config.get.mockImplementation((key) => {
+        const configMap = {
+          ricardoApiLoginUrl: 'https://example.com/token',
+          ricardoApiEmail: 'test@example.com',
+          ricardoApiPassword: 'password123'
+        }
+        return configMap[key]
+      })
+
+      const secretToken = 'super-secret-bearer-token-should-not-be-logged'
+      mockCatchProxyFetchError.mockResolvedValue([200, { token: secretToken }])
+
+      const token = await fetchOAuthToken(mockCatchProxyFetchError, mockLogger)
+
+      expect(token).toBe(secretToken)
+
+      const allLoggedText = [
+        ...mockLogger.info.mock.calls,
+        ...mockLogger.error.mock.calls,
+        ...mockLogger.warn.mock.calls
+      ]
+        .flat()
+        .join('\n')
+
+      expect(allLoggedText).not.toContain(secretToken)
     })
   })
 

--- a/src/api/metOfficeForecast/controllers/connectSftpViaProxy.js
+++ b/src/api/metOfficeForecast/controllers/connectSftpViaProxy.js
@@ -53,7 +53,6 @@ export async function connectSftpThroughProxy() {
 
   return new Promise((resolve, reject) => {
     logger.info(`inside Promise`)
-    logger.info(`privateKey:: ${privateKey}`)
     const req = proxyModule.request(proxyOptions)
     logger.info(`REQUEST:: ${JSON.stringify(req)}`)
     req.on('connect', (res, socket) => {

--- a/src/api/metOfficeForecast/controllers/connectSftpViaProxy.test.js
+++ b/src/api/metOfficeForecast/controllers/connectSftpViaProxy.test.js
@@ -1,0 +1,81 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { Buffer } from 'node:buffer'
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn()
+}))
+const mockConfigGet = vi.hoisted(() => vi.fn())
+const mockHttpRequest = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../config/index.js', () => ({
+  config: { get: mockConfigGet }
+}))
+vi.mock('../../../helpers/logging/logger.js', () => ({
+  createLogger: vi.fn().mockReturnValue(mockLogger)
+}))
+vi.mock('node:http', () => ({
+  default: { request: mockHttpRequest }
+}))
+vi.mock('node:https', () => ({
+  default: { request: vi.fn() }
+}))
+
+class MockSshClient extends EventEmitter {
+  connect() {
+    setImmediate(() => this.emit('ready'))
+    return this
+  }
+
+  sftp(callback) {
+    callback(null, { fake: 'sftp' })
+  }
+}
+
+vi.mock('ssh2', () => ({
+  Client: MockSshClient
+}))
+
+const { connectSftpThroughProxy } = await import('./connectSftpViaProxy.js')
+
+const DECODED_PRIVATE_KEY = 'PRIVATE-KEY-CONTENT-that-must-never-be-logged'
+const ENCODED_PRIVATE_KEY = Buffer.from(DECODED_PRIVATE_KEY).toString('base64')
+
+describe('connectSftpThroughProxy secret logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConfigGet.mockImplementation((key) => {
+      const configMap = {
+        httpProxyNew: 'http://proxy.example.com:3128',
+        sftpPrivateKey: ENCODED_PRIVATE_KEY
+      }
+      return configMap[key]
+    })
+  })
+
+  test('Should never write the decoded private key to any log', async () => {
+    const fakeReq = new EventEmitter()
+    fakeReq.end = vi.fn()
+    mockHttpRequest.mockImplementation(() => {
+      setImmediate(() => {
+        fakeReq.emit('connect', { statusCode: 200 }, {})
+      })
+      return fakeReq
+    })
+
+    const result = await connectSftpThroughProxy()
+
+    expect(result).toHaveProperty('sftp')
+    expect(result).toHaveProperty('conn')
+
+    const allLoggedText = [
+      ...mockLogger.info.mock.calls,
+      ...mockLogger.error.mock.calls
+    ]
+      .flat()
+      .join('\n')
+
+    expect(allLoggedText).not.toContain(DECODED_PRIVATE_KEY)
+  })
+})


### PR DESCRIPTION
This PR covers a security fix applied to stop logging SFTP private key and Ricardo OAuth token as identified recently using AI vulnerability scanning package and detailed as [AQIE-SEC-001]

Changes include adding a new test to make sure its working and not logging the credentials

Link to Jira ticket [HERE ](https://eaflood.atlassian.net/browse/AP-116?atlOrigin=eyJpIjoiNTcyM2Y0MTMxZDM2NDk0YWE4ZGFiY2NkNTE3NTg4ZWYiLCJwIjoiaiJ9)